### PR TITLE
Person Card requires double click

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -19,7 +19,6 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Person;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -138,8 +137,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personDetailView = new PersonDetailView();
+        personDetailView.getRoot().setVisible(false);
+        personDetailViewPlaceholder.getChildren().add(personDetailView.getRoot());
 
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), this::handleSelectedPerson);
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(), personDetailView);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         eventDetailView = new EventDetailView();
@@ -160,24 +161,12 @@ public class MainWindow extends UiPart<Stage> {
         // Displays the first person in the list if exists onto the PersonDetailView
         if (!logic.getFilteredPersonList().isEmpty()) {
             personDetailView.update(logic.getFilteredPersonList().get(0));
-            personDetailViewPlaceholder.getChildren().setAll(personDetailView.getRoot());
         }
 
         // Displays the first event in the list if exists onto the EventDetailView
         if (!logic.getFilteredEventList().isEmpty()) {
             eventDetailView.update(logic.getFilteredEventList().get(0));
         }
-    }
-
-    /**
-     * Sets the person details view to the person selected from the list.
-     * This is a callback handler called from {@code PersonCard} when a given card is clicked by the user.
-     *
-     * @param person The selected person to display in the detail view.
-     */
-    private void handleSelectedPerson(Person person) {
-        personDetailView.update(person);
-        personDetailViewPlaceholder.getChildren().setAll(personDetailView.getRoot());
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -134,6 +134,8 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
+        personDetailView = new PersonDetailView();
+
         personListPanel = new PersonListPanel(logic.getFilteredPersonList(), this::handleSelectedPerson);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
@@ -151,7 +153,7 @@ public class MainWindow extends UiPart<Stage> {
 
         // Displays the first person in the list if exists onto the PersonDetailView
         if (!logic.getFilteredPersonList().isEmpty()) {
-            personDetailView = new PersonDetailView(logic.getFilteredPersonList().get(0));
+            personDetailView.update(logic.getFilteredPersonList().get(0));
             personDetailViewPlaceholder.getChildren().setAll(personDetailView.getRoot());
         }
     }
@@ -163,7 +165,7 @@ public class MainWindow extends UiPart<Stage> {
      * @param person The selected person to display in the detail view.
      */
     private void handleSelectedPerson(Person person) {
-        personDetailView = new PersonDetailView(person);
+        personDetailView.update(person);
         personDetailViewPlaceholder.getChildren().setAll(personDetailView.getRoot());
     }
 

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -37,36 +37,18 @@ public class PersonCard extends UiPart<Region> {
     @FXML
     private FlowPane relationship;
 
-    // Callback to notify when a person is clicked
-    private final PersonSelectionHandler personSelectionHandler;
-
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      * It also allows handling of selection events through the provided {@code PersonSelectionHandler}.
      */
-    public PersonCard(Person person, int displayedIndex, PersonSelectionHandler personSelectionHandler) {
+    public PersonCard(Person person, int displayedIndex) {
         super(FXML);
         this.person = person;
-        this.personSelectionHandler = personSelectionHandler;
 
         id.setText(displayedIndex + ". ");
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);
         relationship.getChildren().add(new Label(person.getRelationship().relationship));
-
-        // Handle click events on the person card
-        getRoot().setOnMouseClicked(event -> {
-            // Notify the personSelectionHandler when a card is clicked
-            personSelectionHandler.handlePersonSelection(person);
-        });
-    }
-
-    /**
-     * Functional interface for person selection handler.
-     */
-    @FunctionalInterface
-    public interface PersonSelectionHandler {
-        void handlePersonSelection(Person person);
     }
 }

--- a/src/main/java/seedu/address/ui/PersonDetailView.java
+++ b/src/main/java/seedu/address/ui/PersonDetailView.java
@@ -46,6 +46,7 @@ public class PersonDetailView extends UiPart<Region> implements DetailView<Perso
     @Override
     public void update(Person person) {
         requireNonNull(person);
+        getRoot().setVisible(true);
         name.setText(person.getName().fullName);
         phone.setText(person.getPhone().value);
         email.setText(person.getEmail().value);

--- a/src/main/java/seedu/address/ui/PersonDetailView.java
+++ b/src/main/java/seedu/address/ui/PersonDetailView.java
@@ -23,8 +23,6 @@ public class PersonDetailView extends UiPart<Region> implements DetailView<Perso
 
     private final Logger logger = LogsCenter.getLogger(getClass());
 
-    private final Person person;
-
     @FXML
     private VBox personDetailView;
     @FXML
@@ -40,12 +38,9 @@ public class PersonDetailView extends UiPart<Region> implements DetailView<Perso
      * Initializes a new {@code PersonDetailView} for displaying the details of the provided {@code Person}.
      * It sets the person's details (name, phone number, email, and relationship) in the view immediately.
      *
-     * @param p The {@code Person} whose details are to be displayed.
      */
-    public PersonDetailView(Person p) {
+    public PersonDetailView() {
         super(FXML);
-        this.person = p;
-        update(p);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -20,23 +20,19 @@ public class PersonListPanel extends UiPart<Region> {
     @FXML
     private ListView<Person> personListView;
 
-    private final PersonCard.PersonSelectionHandler personSelectionHandler;
-
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList<Person>}
      * and a {@code PersonSelectionHandler} for handling user selections of a person.
-     *
-     * @param personList The {@code ObservableList<Person>} that contains the list of persons to be displayed.
-     * @param personSelectionHandler The {@code PersonSelectionHandler}
-     *                               to handle selection events when a person is clicked.
      */
-    public PersonListPanel(ObservableList<Person> personList,
-                           PersonCard.PersonSelectionHandler personSelectionHandler) {
+    public PersonListPanel(ObservableList<Person> personList, PersonDetailView personDetailView) {
         super(FXML);
-        this.personSelectionHandler = personSelectionHandler;
-
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+        personListView.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
+            if (newValue != null) {
+                personDetailView.update(newValue);
+            }
+        });
     }
 
     /**
@@ -51,7 +47,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                PersonCard personCard = new PersonCard(person, getIndex() + 1, personSelectionHandler);
+                PersonCard personCard = new PersonCard(person, getIndex() + 1);
                 setGraphic(personCard.getRoot());
             }
         }


### PR DESCRIPTION
## Describe your changes

Changed from onMouseClick to Listener to detect selecting a `PersonCard`.

Fix a bug where $name, $phone, $email, $relationship were displaying when `addressbook.json` is empty, by setting the default visibility of `PersonDetailView` to false and visible when the `update` method is called.

## Related Issues

#90 

## Type of Change

Bugfix

## Checklist

- [X] Code follows project style guidelines
- [X] I have performed a self-review of my code
- [X] Code is commented where necessary, particularly in hard-to-understand areas
- [ ] ~Tests have been added/updated~
- [ ] ~Documentation has been updated (if applicable)~
- [x] CI checks have passed

## Screenshots (if applicable)

