### PR TITLE
114 fix event detail view

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -62,7 +62,7 @@ public class Messages {
         StringBuilder attendeesString = new StringBuilder();
 
         for (Person attendee : event.getAttendees()) {
-            attendeesString.append('\n').append(attendee.toString());
+            attendeesString.append('\n').append(attendee.toDisplayString());
         }
 
         builder.append(event.getEventName())

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -102,4 +102,16 @@ public class Person {
                 .toString();
     }
 
+    /**
+     * Returns a human-readable version of the data stored in the Person object.
+     */
+    public String toDisplayString() {
+        return new StringBuilder()
+                .append("Name: " + name + ", ")
+                .append("Phone: " + phone + ", ")
+                .append("Email: " + email + ", ")
+                .append("Relationship: " + relationship)
+                .toString();
+    }
+
 }

--- a/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedEvent.java
@@ -21,7 +21,7 @@ public class JsonAdaptedEvent {
     private final String eventName;
     private final LocalDate eventDate;
     private final Set<JsonAdaptedPerson> attendees = new HashSet<>();
-    private final Address location;
+    private final String location;
 
     /**
      * Constructs a {@code JsonAdaptedEvent} with the given event details.
@@ -30,7 +30,7 @@ public class JsonAdaptedEvent {
     public JsonAdaptedEvent(@JsonProperty("eventName") String eventName,
                             @JsonProperty("eventDate") LocalDate eventDate,
                             @JsonProperty("attendees") Set<JsonAdaptedPerson> attendees,
-                            @JsonProperty("location") Address location) {
+                            @JsonProperty("location") String location) {
         this.eventName = eventName;
         this.eventDate = eventDate;
         if (attendees != null) {
@@ -46,7 +46,7 @@ public class JsonAdaptedEvent {
         eventName = source.getEventName();
         eventDate = source.getDate();
         attendees.addAll(source.getAttendees().stream().map(JsonAdaptedPerson::new).collect(Collectors.toSet()));
-        location = source.getLocation();
+        location = source.getLocation().toString();
     }
 
     /**
@@ -59,7 +59,7 @@ public class JsonAdaptedEvent {
         for (JsonAdaptedPerson attendee : attendees) {
             modelAttendees.add(attendee.toModelType());
         }
-        return new Event(eventName, eventDate, location, modelAttendees);
+        return new Event(eventName, eventDate, new Address(location), modelAttendees);
 
     }
 }

--- a/src/main/java/seedu/address/ui/EventDetailView.java
+++ b/src/main/java/seedu/address/ui/EventDetailView.java
@@ -2,6 +2,8 @@ package seedu.address.ui;
 
 import java.time.format.DateTimeFormatter;
 
+import javafx.beans.Observable;
+import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
@@ -15,6 +17,7 @@ import seedu.address.model.event.Event;
 public class EventDetailView extends UiPart<Region> implements DetailView<Event> {
     private static final String FXML = "EventDetailView.fxml";
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("MMM d, yyyy");
+    private ObservableList<Event> eventsList;
 
     @FXML
     private Label title;
@@ -28,8 +31,20 @@ public class EventDetailView extends UiPart<Region> implements DetailView<Event>
     @FXML
     private VBox attendees;
 
-    public EventDetailView() {
+    public EventDetailView(ObservableList<Event> eventsList) {
         super(FXML);
+        this.eventsList = eventsList;
+        if (eventsList.isEmpty()) {
+            this.getRoot().setVisible(false);
+        }
+
+        this.eventsList.addListener((Observable observable) -> {
+            if (eventsList.isEmpty()) {
+                this.getRoot().setVisible(false);
+            } else {
+                this.update(eventsList.get(0));
+            }
+        });
     }
 
     /**
@@ -39,6 +54,7 @@ public class EventDetailView extends UiPart<Region> implements DetailView<Event>
      */
     @Override
     public void update(Event event) {
+        this.getRoot().setVisible(true);
         title.setText(event.getEventName());
         date.setText(event.getDate().format(DATE_FORMATTER));
         locationLabel.setText(event.getLocation().value);

--- a/src/main/java/seedu/address/ui/EventDetailView.java
+++ b/src/main/java/seedu/address/ui/EventDetailView.java
@@ -31,6 +31,14 @@ public class EventDetailView extends UiPart<Region> implements DetailView<Event>
     @FXML
     private VBox attendees;
 
+    /**
+     * Constructs an {@code EventDetailView} to display detailed information
+     * about a {@code Event}, including the event name, date, location, and
+     * event attendees. The view updates automatically when there are changes
+     * in the provided list of {@code Event}s.
+     *
+     * @param eventsList The event list of the EventBook.
+     */
     public EventDetailView(ObservableList<Event> eventsList) {
         super(FXML);
         this.eventsList = eventsList;

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -143,7 +143,7 @@ public class MainWindow extends UiPart<Stage> {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList(), personDetailView);
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
-        eventDetailView = new EventDetailView();
+        eventDetailView = new EventDetailView(logic.getFilteredEventList());
         eventDetailViewPlaceholder.getChildren().clear();
         eventListPanel = new EventListPanel(logic.getFilteredEventList(), eventDetailView);
         eventListPanelPlaceholder.getChildren().add(eventListPanel.getRoot());


### PR DESCRIPTION
## Describe your changes

Fixed event detail view to hide it when event list is empty. 

Additional changes: 
- Updated string representation of `Person` objects to be more human-readable in the response string to the user
- Fixed serialization of `Address` objects (was being serialized to `"location": { "value": "..." }` instead of `"location": "..."`

## Related Issues

Closes #114 

## Type of Change

Bugfix

## Checklist

- [x] Code follows project style guidelines
- [x] I have performed a self-review of my code
- [x] Code is commented where necessary, particularly in hard-to-understand areas
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if applicable)
- [x] CI checks have passed

## Screenshots (if applicable)
Updated string representation for `Person`:
<img width="1116" alt="Screenshot 2024-10-29 at 12 23 19 AM" src="https://github.com/user-attachments/assets/ba9ac4a7-9775-43b9-a467-f3f6cea36910">
