### PR TITLE
Enhance event equality check

### DIFF
--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -93,13 +93,29 @@ public class Event {
         if (otherEvent == this) {
             return true;
         }
+        if (otherEvent == null) {
+            return false;
+        }
 
-        return otherEvent != null
-                && otherEvent.getEventName().equals(getEventName())
+        // check if one event's attendees is subset of another
+        Set<Person> otherEventAttendees = otherEvent.getAttendees();
+        boolean otherEventAttendeesAreAttending = this.checkIfAttendeesAreAttending(otherEventAttendees);
+        boolean eventAttendeesAreAttendingOtherEvent = otherEvent.checkIfAttendeesAreAttending(this.getAttendees());
+
+        return otherEvent.getEventName().equals(getEventName())
                 && otherEvent.startDate.equals(startDate)
                 && otherEvent.endDate.equals(endDate)
-                && otherEvent.getAttendees().equals(getAttendees())
+                && (otherEventAttendeesAreAttending || eventAttendeesAreAttendingOtherEvent)
                 && location.equals(otherEvent.location);
+    }
+
+    /**
+     * Checks if a given set of attendees are all attending the event.
+     * @param attendeesToCheck the set of attendess to check.
+     * @return true if all attendees are attending thes event.
+     */
+    private boolean checkIfAttendeesAreAttending(Set<Person> attendeesToCheck) {
+        return this.getAttendees().containsAll(attendeesToCheck);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/event/exceptions/DuplicateEventException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/DuplicateEventException.java
@@ -1,0 +1,10 @@
+package seedu.address.model.event.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Events.
+ */
+public class DuplicateEventException extends RuntimeException {
+    public DuplicateEventException() {
+        super("Operation would result in duplicate events");
+    }
+}


### PR DESCRIPTION
## Describe your changes

Updated the Event object's equality check.
Events A and B are the same if and only if
1. All fields, except attendees, of A are equal to that of B.
2. Attendees of A is a subset of Attendees of B, or vise-versa.

## Related Issues

closes #146 

## Type of Change

Bugfix / Enhancement

## Checklist

- [x] Code follows project style guidelines
- [x] I have performed a self-review of my code
- [x] Code is commented where necessary, particularly in hard-to-understand areas
- [x] Tests have been added/updated
- [ ] Documentation has been updated (if applicable)
- [x] CI checks have passed

