### PR TITLE
Revert event equality changes

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -301,6 +301,7 @@ Furthermore, certain edits can cause the LegacyLink to behave in unexpected ways
 
 1. **When using multiple screens**, if you move the application to a secondary screen, and later switch to using only the primary screen, the GUI will open off-screen. The remedy is to delete the `preferences.json` file created by the application before running the application again.
 2. **If you minimize the Help Window** and then run the `help` command (or use the `Help` menu, or the keyboard shortcut `F1`) again, the original Help Window will remain minimized, and no new Help Window will appear. The remedy is to manually restore the minimized Help Window.
+3. **When creating 2 or more events that have the same name, start date, end date, and location**, it is possible for these events to have attendees which are subsets for each other, but not equal to each other. The remedy is to implement a more sophisticated duplicate event detection system to enhance user experience in the future.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/src/main/java/seedu/address/logic/commands/UpdateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/UpdateCommand.java
@@ -87,6 +87,8 @@ public class UpdateCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
+        // TODO: add handling for integer overflow here,
+        //  OR specify in UG that integers for index beyond max int are considered out of bounds.
         if (indexToUpdate.getZeroBased() >= model.getEventListLength()
                 || indexToUpdate.getZeroBased() < 0) {
             throw new CommandException(MESSAGE_INDEX_OUT_OF_BOUNDS);

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -97,25 +97,11 @@ public class Event {
             return false;
         }
 
-        // check if one event's attendees is subset of another
-        Set<Person> otherEventAttendees = otherEvent.getAttendees();
-        boolean otherEventAttendeesAreAttending = this.checkIfAttendeesAreAttending(otherEventAttendees);
-        boolean eventAttendeesAreAttendingOtherEvent = otherEvent.checkIfAttendeesAreAttending(this.getAttendees());
-
         return otherEvent.getEventName().equals(getEventName())
                 && otherEvent.startDate.equals(startDate)
                 && otherEvent.endDate.equals(endDate)
-                && (otherEventAttendeesAreAttending || eventAttendeesAreAttendingOtherEvent)
+                && otherEvent.attendees.equals(attendees)
                 && location.equals(otherEvent.location);
-    }
-
-    /**
-     * Checks if a given set of attendees are all attending the event.
-     * @param attendeesToCheck the set of attendess to check.
-     * @return true if all attendees are attending thes event.
-     */
-    private boolean checkIfAttendeesAreAttending(Set<Person> attendeesToCheck) {
-        return this.getAttendees().containsAll(attendeesToCheck);
     }
 
     @Override


### PR DESCRIPTION
## Describe your changes

Reverted previous event equality changes due to bug-prone changes.
1. Event equality now compares attendees using Java Set's .equals method. This means that if events A and B have same fields for everything, but event A has attendees which are a subset of event B's attendees, A.equals(B) == false.
2. This behaviour will be considered under 'known issues' in the UG.
3. The bug where update command could allow a user to update an event until it had the same fields as another event is still fixed, as there is a check in the UpdateCommand's execute method to check if the updated command already exists in the address book.

## Related Issues

closes #190 

## Type of Change

Bugfix / Enhancement

## Checklist

- [x] Code follows project style guidelines
- [x] I have performed a self-review of my code
- [x] Code is commented where necessary, particularly in hard-to-understand areas
- [ ] Tests have been added/updated
- [x] Documentation has been updated (if applicable)
- [x] CI checks have passed
