### PR TITLE
Add Event Formatting Fix

### DIFF
--- a/src/main/java/seedu/address/logic/parser/EventCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EventCommandParser.java
@@ -48,10 +48,8 @@ public class EventCommandParser implements Parser<EventCommand> {
 
             Address location = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_LOCATION).get().trim());
 
-            String indexes = (arePrefixesPresent(argMultimap, PREFIX_ATTENDEES))
-                             ? argMultimap.getValue(PREFIX_ATTENDEES).get()
-                             : " ";
-            Set<Index> attendeeIndexes = ParserUtil.parseIndexes(indexes);
+            String attendeeIndices = argMultimap.getValue(PREFIX_ATTENDEES).orElse("");
+            Set<Index> attendeeIndexes = ParserUtil.parseAttendeeIndices(attendeeIndices, true);
 
             return new EventCommand(name, startDate, endDate, location, attendeeIndexes);
         } catch (DateTimeParseException e) {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -62,6 +62,40 @@ public class ParserUtil {
         return indexes;
     }
 
+
+    /**
+     * Parses and validates a string of attendee indices.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @param indices The string of space-separated indices
+     * @param allowEmpty Whether an empty string is considered valid
+     * @return Set of parsed Index objects
+     * @throws ParseException if the format is invalid or indices are not positive integers
+     */
+    public static Set<Index> parseAttendeeIndices(String indices, boolean allowEmpty) throws ParseException {
+        String trimmedIndices = indices.trim();
+
+        if (trimmedIndices.isEmpty()) {
+            if (allowEmpty) {
+                return new HashSet<>();
+            }
+            throw new ParseException(String.format(
+                    "Attendee list cannot be empty. Expected format: space-separated numbers (e.g. 1 2 3)"));
+        }
+
+        try {
+            Set<Index> parsedIndices = parseIndexes(trimmedIndices);
+            if (parsedIndices.isEmpty()) {
+                throw new ParseException(String.format(
+                        "No valid indices found. Expected format: space-separated numbers (e.g. 1 2 3)"));
+            }
+            return parsedIndices;
+        } catch (ParseException e) {
+            throw new ParseException(String.format(
+                    "Invalid format for attendee indices. Expected format: space-separated numbers (e.g. 1 2 3)"));
+        }
+    }
+
     /**
      * Parses a {@code String name} into a {@code Name}.
      * Leading and trailing whitespaces will be trimmed.

--- a/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/UpdateCommandParser.java
@@ -73,8 +73,25 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
             ParserUtil.checkValidDates(startDate, endDate);
         }
         Address location = parseLocation(argMultimap);
-        Set<Index> addIndices = parseAttendeeIndices(argMultimap, PREFIX_ATTENDEES);
-        Set<Index> removeIndices = parseAttendeeIndices(argMultimap, PREFIX_REMOVE_ATTENDEE);
+
+
+        // Updated attendee parsing
+        Set<Index> addIndices = new HashSet<>();
+        Set<Index> removeIndices = new HashSet<>();
+
+        if (arePrefixesPresent(argMultimap, PREFIX_ATTENDEES)) {
+            addIndices = ParserUtil.parseAttendeeIndices(
+                    argMultimap.getValue(PREFIX_ATTENDEES).get(),
+                    false
+            );
+        }
+
+        if (arePrefixesPresent(argMultimap, PREFIX_REMOVE_ATTENDEE)) {
+            removeIndices = ParserUtil.parseAttendeeIndices(
+                    argMultimap.getValue(PREFIX_REMOVE_ATTENDEE).get(),
+                    false
+            );
+        }
 
         return new UpdateCommand(name, startDate, endDate, location, addIndices, removeIndices, indexToUpdate);
     }
@@ -184,24 +201,5 @@ public class UpdateCommandParser implements Parser<UpdateCommand> {
         return null;
     }
 
-    /**
-     * Parses and returns the set of attendee indices to be added or deleted.
-     *
-     * @param argMultimap The map of arguments to their values.
-     * @return The set of attendee indices to be added or deleted.
-     * @throws ParseException If attendee list is empty or
-     *     the supplied index is not a valid integer.
-     */
-    private Set<Index> parseAttendeeIndices(ArgumentMultimap argMultimap, Prefix prefix)
-            throws ParseException {
-        Set<Index> attendeeIndices = new HashSet<>();
-        if (arePrefixesPresent(argMultimap, prefix)) {
-            attendeeIndices.addAll(ParserUtil.parseIndexes(argMultimap.getValue(prefix).orElse("")));
-            if (attendeeIndices.isEmpty()) {
-                throw new ParseException(String.format("Attendee list cannot be empty. \n%1$s",
-                        UpdateCommand.MESSAGE_USAGE));
-            }
-        }
-        return attendeeIndices;
-    }
+
 }


### PR DESCRIPTION
## Describe your changes

When a command like  ``event -n Get Together Party -sd 2023-10-25 -ed 2023-10-27 -l MBS -a 1, 2, 3`` is provided, the error message was not helpful. Similarly for the update command. The error message is now more useful:
- ``Expected format: space-separated numbers (e.g. 1 2 3)``

## Related Issues

Fixes #231 

## Type of Change

Bug Fix

## Checklist

- [X] Code follows project style guidelines
- [X] I have performed a self-review of my code
- [X] Code is commented where necessary, particularly in hard-to-understand areas
- [X] Tests have been added/updated
- [X] Documentation has been updated (if applicable)
- [X] CI checks have passed

## Screenshots (if applicable)
![image](https://github.com/user-attachments/assets/9f08ac4a-30bb-46b2-9fa3-56c605ae52a5)

![image](https://github.com/user-attachments/assets/5ae8bbd0-5e5d-431f-81ca-74b7d9e11fd7)

